### PR TITLE
feat: add nixfmt-rfc-style formatter to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,10 @@
           ];
         };
       };
+
+      # Formatter for nix files
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
+
       checks = forAllSystems (system: {
         pre-commit-check = inputs.pre-commit-hooks.lib.${system}.run {
           src = ./.;


### PR DESCRIPTION
- Add formatter output for consistent code formatting
- Use nixfmt-rfc-style as the standard formatter
- Enable nix fmt command for the project