### PR TITLE
fix: pin kernel version to 6.15 to resolve gamepad build issues

### DIFF
--- a/hosts/eto/boot.nix
+++ b/hosts/eto/boot.nix
@@ -3,7 +3,7 @@
 {
   boot = {
     loader.systemd-boot.enable = true;
-    kernelPackages = pkgs.linuxPackages_latest;
+    kernelPackages = pkgs.linuxPackages_6_15;
     kernelParams = [ "console=ttyS0,115200" ];
     kernel.sysctl = {
       "fs.inotify.max_user_instances" = 8192;


### PR DESCRIPTION
The latest kernel packages have a broken gamepad driver build. Pin to Linux 6.15 until the upstream issue is resolved.