### PR TITLE
feat: add fingerprint scanner support with 1Password integration

### DIFF
--- a/hosts/eto/default.nix
+++ b/hosts/eto/default.nix
@@ -23,7 +23,9 @@
     ../../modules/profiles/developer.nix
     ../../modules/profiles/japanese.nix
     ../../modules/services/ssh.nix
+    ../../modules/services/polkit-agent.nix
     ../../modules/security/certificates.nix
+    ../../modules/security/fingerprint.nix
 
     # User configuration
     ./users.nix
@@ -85,8 +87,26 @@
       '';
     };
 
+    services.polkitAgent = {
+      enable = true;
+      package = pkgs.polkit_gnome; # Lightweight, works well with XMonad
+    };
+
     security.certificates = {
       enableInternalCAs = true;
+    };
+
+    security.fingerprint = {
+      enable = true;
+      enablePAM = true;
+      autoDetectDisplayManager = true; # Automatically configures LightDM
+      # Extended PAM services for comprehensive fingerprint support
+      pamServices = [
+        "login" # Console login
+        "sudo" # Elevated commands
+        "polkit-1" # GUI authentication dialogs
+        "lightdm-greeter" # Login screen (additional to auto-detected lightdm)
+      ];
     };
   };
 

--- a/hosts/eto/programs.nix
+++ b/hosts/eto/programs.nix
@@ -12,5 +12,13 @@
       gamescopeSession.enable = true;
     };
     gamemode.enable = true;
+
+    _1password = {
+      enable = true;
+    };
+    _1password-gui = {
+      enable = true;
+      polkitPolicyOwners = [ "claude" ];
+    };
   };
 }

--- a/hosts/eto/users.nix
+++ b/hosts/eto/users.nix
@@ -10,6 +10,7 @@
       "docker"
       "libvirtd"
       "vboxusers"
+      "plugdev" # For fingerprint scanner access
     ];
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICHtv7BugMwASTVv4+FZi3HlSke0cCNogLuTQQVm/aWc"

--- a/modules/security/fingerprint.nix
+++ b/modules/security/fingerprint.nix
@@ -1,0 +1,107 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.modules.security.fingerprint;
+in
+{
+  options.modules.security.fingerprint = {
+    enable = mkEnableOption "fingerprint scanner support";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.fprintd;
+      description = "The fprintd package to use";
+    };
+
+    enablePAM = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable PAM integration for fingerprint authentication";
+    };
+
+    pamServices = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "login"
+        "sudo"
+        "polkit-1"
+      ];
+      example = [
+        "login"
+        "lightdm"
+        "gdm"
+        "sddm"
+        "xscreensaver"
+        "sudo"
+        "polkit-1"
+      ];
+      description = "PAM services to enable fingerprint authentication for";
+    };
+
+    autoDetectDisplayManager = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Automatically detect and configure the active display manager";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Enable fprintd service
+    services.fprintd = {
+      enable = true;
+      inherit (cfg) package;
+    };
+
+    # Enable PAM integration
+    security.pam.services = mkIf cfg.enablePAM (
+      let
+        # Auto-detect display manager if enabled
+        autoDetectedServices =
+          cfg.pamServices
+          ++ (
+            if cfg.autoDetectDisplayManager then
+              (optional config.services.xserver.displayManager.lightdm.enable "lightdm")
+              ++ (optional config.services.xserver.displayManager.gdm.enable "gdm")
+              ++ (optional config.services.xserver.displayManager.sddm.enable "sddm")
+              ++ (optional config.services.xserver.enable "xscreensaver")
+            else
+              [ ]
+          );
+      in
+      listToAttrs (
+        map (service: {
+          name = service;
+          value = {
+            fprintAuth = true;
+          };
+        }) autoDetectedServices
+      )
+    );
+
+    # Add fprintd packages
+    environment.systemPackages = with pkgs; [
+      cfg.package
+    ];
+
+    # Ensure the necessary groups exist
+    users.groups.plugdev = { };
+
+    # udev rules for fingerprint scanner access
+    services.udev.extraRules = ''
+      # DigitalPersona 4500 Fingerprint Reader
+      SUBSYSTEM=="usb", ATTRS{idVendor}=="05ba", ATTRS{idProduct}=="0007", MODE="0666", GROUP="plugdev"
+      SUBSYSTEM=="usb", ATTRS{idVendor}=="05ba", ATTRS{idProduct}=="0008", MODE="0666", GROUP="plugdev"
+      SUBSYSTEM=="usb", ATTRS{idVendor}=="05ba", ATTRS{idProduct}=="000a", MODE="0666", GROUP="plugdev"
+
+      # General fingerprint reader rules
+      SUBSYSTEM=="usb", ATTRS{idVendor}=="08ff", MODE="0666", GROUP="plugdev"
+    '';
+  };
+}

--- a/modules/services/polkit-agent.nix
+++ b/modules/services/polkit-agent.nix
@@ -1,0 +1,69 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.modules.services.polkitAgent;
+in
+{
+  options.modules.services.polkitAgent = {
+    enable = mkEnableOption "Polkit authentication agent for standalone window managers";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.polkit_gnome;
+      example = literalExpression ''
+        pkgs.lxqt.lxqt-policykit  # Qt-based, modern UI
+        pkgs.mate.mate-polkit      # MATE desktop agent
+      '';
+      description = "Polkit agent package to use. Different agents have varying fingerprint UI support.";
+    };
+
+    autostart = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to automatically start the agent via systemd user service";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Ensure polkit is enabled
+    security.polkit.enable = true;
+
+    # Add polkit agent to system packages
+    environment.systemPackages = [ cfg.package ];
+
+    # Add polkit rules for 1Password
+    security.polkit.extraConfig = ''
+      // Allow users in wheel group to authenticate with 1Password
+      polkit.addRule(function(action, subject) {
+        if ((action.id == "com.1password.1Password.authorizeCLI" ||
+            action.id == "com.1password.1Password.authorizeSshAgent" ||
+            action.id == "com.1password.1Password.unlock") &&
+            subject.isInGroup("wheel")) {
+          return polkit.Result.AUTH_SELF;
+        }
+      });
+    '';
+
+    # Create systemd user service for automatic startup
+    systemd.user.services.polkit-agent = mkIf cfg.autostart {
+      description = "Polkit authentication agent";
+      wantedBy = [ "graphical-session.target" ];
+      wants = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/libexec/polkit-gnome-authentication-agent-1";
+        Restart = "on-failure";
+        RestartSec = 1;
+        TimeoutStopSec = 10;
+      };
+    };
+  };
+}


### PR DESCRIPTION
- Create fingerprint security module with fprintd and PAM integration
  - Auto-detect display manager for PAM configuration
  - Support for DigitalPersona 4500 USB fingerprint scanner
  - Configure udev rules for device access

- Add Polkit agent module for standalone window managers
  - Automatic startup via systemd user service
  - Configure Polkit rules for 1Password authentication
  - Support multiple agent implementations

- Enable comprehensive OS integration
  - System login via LightDM
  - Screen locking via dm-tool
  - sudo command authentication
  - 1Password GUI unlock

- Update host configuration
  - Add user to plugdev group
  - Enable 1Password with fingerprint support
  - Configure appropriate PAM services