### PR TITLE
fix: update SDDM configuration to use new displayManager location

### DIFF
--- a/modules/profiles/desktop.nix
+++ b/modules/profiles/desktop.nix
@@ -63,16 +63,13 @@ in
           enable = true;
           xkb.layout = mkDefault "us";
 
-          # Display manager
+          # Display manager - LightDM and GDM still under xserver
           displayManager = mkMerge [
             (mkIf (cfg.displayManager == "lightdm") {
               lightdm.enable = true;
             })
             (mkIf (cfg.displayManager == "gdm") {
               gdm.enable = true;
-            })
-            (mkIf (cfg.displayManager == "sddm") {
-              sddm.enable = true;
             })
             {
               sessionCommands = ''
@@ -92,6 +89,10 @@ in
           ];
         };
       }
+      # SDDM configuration (new location)
+      (mkIf (cfg.displayManager == "sddm") {
+        displayManager.sddm.enable = true;
+      })
       # Default session
       {
         displayManager.defaultSession = mkIf (cfg.windowManager != "none") "none+${cfg.windowManager}";

--- a/modules/security/fingerprint.nix
+++ b/modules/security/fingerprint.nix
@@ -69,7 +69,7 @@ in
             if cfg.autoDetectDisplayManager then
               (optional config.services.xserver.displayManager.lightdm.enable "lightdm")
               ++ (optional config.services.xserver.displayManager.gdm.enable "gdm")
-              ++ (optional config.services.xserver.displayManager.sddm.enable "sddm")
+              ++ (optional config.services.displayManager.sddm.enable "sddm")
               ++ (optional config.services.xserver.enable "xscreensaver")
             else
               [ ]


### PR DESCRIPTION
NixOS has moved SDDM configuration from services.xserver.displayManager.sddm to services.displayManager.sddm while keeping LightDM and GDM in the old location.

Changes:
- Move SDDM enable to services.displayManager.sddm.enable in desktop module
- Keep LightDM and GDM under services.xserver.displayManager
- Update fingerprint module to use correct paths for each display manager
- Eliminate 'Obsolete option' trace warning