### PR TITLE
fix: Add kernel 6.16 compatibility fix

### DIFF
--- a/hosts/eto/boot.nix
+++ b/hosts/eto/boot.nix
@@ -1,13 +1,25 @@
-{ pkgs, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   boot = {
     loader.systemd-boot.enable = true;
-    kernelPackages = pkgs.linuxPackages_6_15;
+    # Use latest kernel (6.16+)
+    kernelPackages = pkgs.unstable.linuxPackages_latest;
     kernelParams = [ "console=ttyS0,115200" ];
     kernel.sysctl = {
       "fs.inotify.max_user_instances" = 8192;
     };
     supportedFilesystems = [ "ntfs" ];
   };
+
+  # Fix for kernel 6.16 module structure changes
+  # This is required due to changes between kernel 6.15 and 6.16
+  system.modulesTree = [
+    (lib.getOutput "modules" config.boot.kernelPackages.kernel)
+  ];
 }


### PR DESCRIPTION
- Add system.modulesTree configuration to handle module structure changes in kernel 6.16
- This resolves the 'Module xhci_pci not found' error when building with linuxPackages_latest
- The fix addresses changes in module handling between kernel 6.15 and 6.16

References: https://www.reddit.com/r/NixOS/comments/1n7bscz/