### PR TITLE
feat: Add virgil WSL host and improve multi-host management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        host: [eto]
+        host: [eto, virgil]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -37,18 +53,38 @@
         "type": "github"
       }
     },
+    "nixos-wsl": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1755261305,
+        "narHash": "sha256-EOqCupB5X5WoGVHVcfOZcqy0SbKWNuY3kq+lj1wHdu8=",
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "rev": "203a7b463f307c60026136dd1191d9001c43457f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "main",
+        "repo": "NixOS-WSL",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757020766,
-        "narHash": "sha256-PLoSjHRa2bUbi1x9HoXgTx2AiuzNXs54c8omhadyvp0=",
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe83bbdde2ccdc2cb9573aa846abe8363f79a97a",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -71,6 +107,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1757020766,
+        "narHash": "sha256-PLoSjHRa2bUbi1x9HoXgTx2AiuzNXs54c8omhadyvp0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fe83bbdde2ccdc2cb9573aa846abe8363f79a97a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1754340878,
         "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
         "owner": "NixOS",
@@ -87,9 +139,9 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1755960406,
@@ -107,7 +159,8 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "nixos-wsl": "nixos-wsl",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "pre-commit-hooks": "pre-commit-hooks"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,8 @@
 
             # Host-specific configuration
             ./hosts/${hostName}/default.nix
-          ] ++ (nixpkgs.lib.optional (hostType == "wsl") inputs.nixos-wsl.nixosModules.default);
+          ]
+          ++ (nixpkgs.lib.optional (hostType == "wsl") inputs.nixos-wsl.nixosModules.default);
         };
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixos-wsl.url = "github:nix-community/NixOS-WSL/main";
     pre-commit-hooks.url = "github:cachix/git-hooks.nix";
   };
 
@@ -19,17 +20,61 @@
         "aarch64-linux"
       ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Helper function to create host configurations
+      mkHost =
+        {
+          hostName,
+          system ? "x86_64-linux",
+          hostType ? "physical", # physical, wsl, vm
+          hostRoles ? [ ], # desktop, development, server
+        }:
+        nixpkgs.lib.nixosSystem {
+          inherit system;
+          specialArgs = {
+            inherit
+              inputs
+              hostName
+              hostType
+              hostRoles
+              ;
+          };
+          modules = [
+            # Base configuration for all hosts
+            ./modules/profiles/base.nix
+
+            # Type-specific configuration
+            (
+              if hostType == "wsl" then
+                ./modules/profiles/wsl.nix
+              else if hostType == "physical" then
+                ./modules/profiles/physical.nix
+              else
+                { } # VM or other types can be added later
+            )
+
+            # Host-specific configuration
+            ./hosts/${hostName}/default.nix
+          ] ++ (nixpkgs.lib.optional (hostType == "wsl") inputs.nixos-wsl.nixosModules.default);
+        };
     in
     {
       nixosConfigurations = {
-        eto = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          specialArgs = {
-            inherit inputs;
-          };
-          modules = [
-            ./hosts/eto/default.nix
+        # Physical desktop machine
+        eto = mkHost {
+          hostName = "eto";
+          hostType = "physical";
+          hostRoles = [
+            "desktop"
+            "development"
           ];
+        };
+
+        # WSL development environment
+        virgil = mkHost {
+          hostName = "virgil";
+          hostType = "wsl";
+          hostRoles = [ "development" ];
         };
       };
 

--- a/hosts/virgil/_1passwordWrapper.nix
+++ b/hosts/virgil/_1passwordWrapper.nix
@@ -1,0 +1,103 @@
+{ pkgs, ... }:
+{
+  environment.systemPackages = [
+    (pkgs.writeShellScriptBin "op" ''
+      #!/usr/bin/env bash
+      # Wrapper: invoke Windows 1Password CLI (op.exe) from WSL
+      # Notes:
+      # - Prefer WinGet Links location if present.
+      # - On drvfs, ".exe" may not have +x; use "-f" instead of "-x".
+      # Style: Google Shell Style + ShellCheck-friendly
+      set -euo pipefail
+      IFS=$'\n\t'
+
+      die() {
+        printf '%s\n' "ERROR: $*" >&2
+        exit 1
+      }
+
+      have() { command -v "''$1" >/dev/null 2>&1; }
+
+      read_win_env() {
+        # Usage: read_win_env VAR_NAME
+        # Reads a Windows environment variable via cmd.exe without CR.
+        local name value
+        name="''$1"
+        value=$(/mnt/c/Windows/System32/cmd.exe /C "echo %''${name}%" 2>/dev/null | tr -d '\r')
+        # cmd.exe echoes the literal if undefined; detect that case.
+        [[ "''${value}" == "%''${name}%" || -z "''${value}" ]] && return 1
+        printf '%s' "''${value}"
+      }
+
+      resolve_localappdata_path() {
+        # Resolve LOCALAPPDATA and convert to WSL path.
+        local lad lad_wsl
+        lad="$(read_win_env LOCALAPPDATA)" || return 1
+        lad_wsl="$(wslpath -u "''${lad}")"
+        printf '%s' "''${lad_wsl}"
+      }
+
+      candidate_paths() {
+        # Generate possible locations for op.exe (most specific first).
+        # 0) Explicit override via env.
+        if [[ -n "''${OP_WINDOWS_EXE:-}" ]]; then
+          printf '%s\n' "''${OP_WINDOWS_EXE}"
+        fi
+
+        # 1) WinGet shim path: %LOCALAPPDATA%\Microsoft\WinGet\Links\op.exe
+        local lad
+        if lad="$(resolve_localappdata_path)"; then
+          printf '%s\n' "''${lad}/Microsoft/WinGet/Links/op.exe"
+        fi
+
+        # 2) Standard per-user installs under LOCALAPPDATA.
+        if [[ -n "''${lad:-}" ]]; then
+          printf '%s\n' "''${lad}/1Password/op.exe"
+          printf '%s\n' "''${lad}/1Password CLI/op.exe"
+          printf '%s\n' "''${lad}/Programs/1Password/op.exe"
+          # Extra fallback: scan app subfolders if present (bounded depth).
+          if have find; then
+            find "''${lad}" -maxdepth 4 -type f -name 'op.exe' 2>/dev/null || true
+          fi
+        fi
+
+        # 3) Per-user path via USERNAME (in case LOCALAPPDATA failed).
+        local user
+        if user="$(read_win_env USERNAME)"; then
+          printf '%s\n' "/mnt/c/Users/''${user}/AppData/Local/Microsoft/WinGet/Links/op.exe"
+          printf '%s\n' "/mnt/c/Users/''${user}/AppData/Local/1Password/op.exe"
+          printf '%s\n' "/mnt/c/Users/''${user}/AppData/Local/1Password CLI/op.exe"
+          printf '%s\n' "/mnt/c/Users/''${user}/AppData/Local/Programs/1Password/op.exe"
+        fi
+
+        # 4) Machine-wide fallbacks.
+        printf '%s\n' "/mnt/c/Program Files/1Password/op.exe"
+        printf '%s\n' "/mnt/c/Program Files/1Password CLI/op.exe"
+      }
+
+      find_op_exe() {
+        # Pick the first existing op.exe from candidates.
+        local p
+        while IFS= read -r p; do
+          [[ -n "''${p}" && -f "''${p}" ]] && { printf '%s' "''${p}"; return 0; }
+        done < <(candidate_paths)
+        return 1
+      }
+
+      sanity_checks() {
+        # Ensure required tools are available.
+        have wslpath || die "wslpath not found. Enable interop and ensure WSL tools are available."
+        [[ -f /mnt/c/Windows/System32/cmd.exe ]] || die "cmd.exe not reachable at /mnt/c/Windows/System32/cmd.exe"
+      }
+
+      main() {
+        sanity_checks
+        local op_exe
+        op_exe="$(find_op_exe)" || die "op.exe not found. Install 1Password CLI or set OP_WINDOWS_EXE."
+        exec "''${op_exe}" "''$@"
+      }
+
+      main "''$@"
+    '')
+  ];
+}

--- a/hosts/virgil/default.nix
+++ b/hosts/virgil/default.nix
@@ -1,0 +1,36 @@
+# virgil - WSL development environment configuration
+{
+  config,
+  lib,
+  pkgs,
+  hostRoles,
+  ...
+}:
+
+{
+  imports = [
+    # User configuration
+    ./users.nix
+
+    # Host-specific configurations
+    ./programs.nix
+    ./_1passwordWrapper.nix
+  ];
+
+  # Module configuration
+  modules = {
+    # CPU-specific optimization
+    system.nix.maxJobs = 28;
+
+    # Developer configuration
+    profiles.developer = {
+      languages = [
+        "c"
+        "nix"
+      ];
+      editor = "emacs";
+    };
+  };
+
+  # No special packages needed beyond base and WSL profiles
+}

--- a/hosts/virgil/programs.nix
+++ b/hosts/virgil/programs.nix
@@ -1,0 +1,5 @@
+{
+  programs = {
+    fish.enable = true;
+  };
+}

--- a/hosts/virgil/users.nix
+++ b/hosts/virgil/users.nix
@@ -1,0 +1,19 @@
+{
+  users.users.claude = {
+    isNormalUser = true;
+    home = "/home/claude";
+    description = "Takafumi Asano";
+    shell = "/run/current-system/sw/bin/fish";
+    extraGroups = [
+      "wheel"
+      "networkmanager"
+    ];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICHtv7BugMwASTVv4+FZi3HlSke0cCNogLuTQQVm/aWc"
+      # Biometric key for Terminus on the device "zoè"
+      "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA0Izr6fwz7d/QNd3sao8KW7ymotB/HOFkM9V/V44NGxR95tktSX0zlEGM5OSTsLp35qemH6ix5z29RzPowJVsg="
+      # Biometric key for Terminus on the device "russell"
+      "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBj8Q6cfjjNjgL9rlMxNkffiS/YyHjtwulHQR+7/ugJhRRm+5i7hxlEmYVjK74IIPHfo9UrXVOxkmfaKgnIVDDU="
+    ];
+  };
+}

--- a/modules/profiles/base.nix
+++ b/modules/profiles/base.nix
@@ -1,0 +1,92 @@
+# Base configuration for all hosts
+# This module contains settings common to all machines
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  hostName,
+  hostType ? "physical",
+  hostRoles ? [ ],
+  ...
+}:
+
+{
+  imports = [
+    ../system/nix.nix
+    ../services/ssh.nix
+    ../profiles/japanese.nix
+  ];
+
+  # Host identification
+  networking.hostName = hostName;
+
+  # Base modules configuration
+  modules = {
+    system.nix = {
+      enable = true;
+      trustedUsers = [
+        "root"
+        "claude"
+      ];
+      maxJobs = lib.mkDefault 4; # Can be overridden per host
+      allowUnfree = true;
+    };
+
+    services.ssh = {
+      enable = true;
+      extraConfig = ''
+        StreamLocalBindUnlink yes
+        UseDNS no
+      '';
+    };
+
+    profiles.japanese = {
+      enable = true;
+      defaultLocale = "en_US.UTF-8";
+      timezone = "Asia/Tokyo";
+    };
+  };
+
+  # Unstable overlay (common to all hosts)
+  nixpkgs.overlays = [
+    (final: prev: {
+      unstable = import inputs.nixpkgs-unstable {
+        inherit (pkgs) system;
+        inherit (config.nixpkgs) config;
+      };
+    })
+  ];
+
+  # Base system packages common to all hosts
+  environment.systemPackages = with pkgs; [
+    # NixOS specific
+    home-manager
+
+    # System monitoring
+    lm_sensors
+    pciutils
+
+    # File management
+    p7zip
+    unzip
+
+    # System utilities
+    dool
+    file
+    htop
+    tree
+
+    # Terminal multiplexers
+    tmux
+    screen
+
+    # Network utilities
+    wget
+    curl
+    nettools
+  ];
+
+  # System state version
+  system.stateVersion = "25.05";
+}

--- a/modules/profiles/physical.nix
+++ b/modules/profiles/physical.nix
@@ -1,0 +1,71 @@
+# Physical machine profile
+# Configuration specific to physical hardware
+{
+  config,
+  lib,
+  pkgs,
+  hostRoles ? [ ],
+  ...
+}:
+
+{
+  imports = [
+    ./desktop.nix
+    ./developer.nix
+    ../security/certificates.nix
+    ../security/fingerprint.nix
+    ../services/polkit-agent.nix
+  ];
+
+  # Module configuration
+  modules = {
+    # Enable desktop if in roles
+    profiles.desktop.enable = lib.mkDefault (lib.elem "desktop" hostRoles);
+
+    # Enable developer profile if in roles
+    profiles.developer.enable = lib.mkDefault (lib.elem "development" hostRoles);
+
+    # Security modules common to physical machines
+    security = lib.mkIf (lib.elem "desktop" hostRoles) {
+      certificates.enableInternalCAs = true;
+
+      fingerprint = {
+        enable = lib.mkDefault false; # Can be enabled per host
+        enablePAM = true;
+        autoDetectDisplayManager = true;
+      };
+    };
+
+    # Polkit agent for desktop environments
+    services.polkitAgent = lib.mkIf (lib.elem "desktop" hostRoles) {
+      enable = true;
+      package = lib.mkDefault pkgs.polkit_gnome;
+    };
+  };
+
+  # Physical machine specific packages
+  environment.systemPackages = with pkgs; [
+    # Hardware monitoring
+    liquidctl
+    stress-ng
+    geekbench
+
+    # Virtualization (usually on physical machines)
+    virt-manager
+    qemu
+    (pkgs.writeShellScriptBin "qemu-system-x86_64-uefi" ''
+      qemu-system-x86_64 \
+        -bios ${pkgs.OVMF.fd}/FV/OVMF.fd \
+        "$@"
+    '')
+  ];
+
+  # Common physical machine services
+  services = {
+    # Power management
+    thermald.enable = lib.mkDefault true;
+
+    # Hardware management
+    fwupd.enable = lib.mkDefault true;
+  };
+}

--- a/modules/profiles/wsl.nix
+++ b/modules/profiles/wsl.nix
@@ -1,0 +1,92 @@
+# WSL profile
+# Configuration specific to Windows Subsystem for Linux
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  hostRoles ? [ ],
+  ...
+}:
+
+{
+  imports = [
+    ./developer.nix
+  ];
+
+  # WSL specific configuration
+  wsl = {
+    enable = true;
+    defaultUser = "claude";
+    interop.register = true;
+
+    # WSL-specific settings
+    wslConf = {
+      automount.root = "/mnt";
+      interop.appendWindowsPath = false;
+      network.generateHosts = false;
+    };
+  };
+
+  # Enable developer profile if in roles
+  modules.profiles.developer = {
+    enable = lib.mkDefault (lib.elem "development" hostRoles);
+    # No containers in WSL by default
+    enableContainers = false;
+  };
+
+  # WSL specific packages
+  environment.systemPackages = with pkgs; [
+    # WSL utilities
+    wslu
+
+    # Network tools for WSL
+    socat
+  ];
+
+  # Systemd configuration for WSL
+  systemd = {
+    # WSL doesn't support all systemd features
+    enableEmergencyMode = false;
+
+    # Common WSL mount for SSH keys
+    mounts = lib.mkDefault [
+      {
+        what = "/mnt/c/Users/caria/.ssh";
+        where = "/home/claude/.ssh";
+        type = "none";
+        options = "bind";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "mnt-c.mount" ];
+        requires = [ "mnt-c.mount" ];
+      }
+    ];
+
+    # Fix SSH permissions after bind mount
+    services.fix-ssh-permissions = {
+      description = "Fix permissions for ~/.ssh after bind mount";
+      after = [ "home-claude-.ssh.mount" ];
+      requires = [ "home-claude-.ssh.mount" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.coreutils}/bin/chmod 700 /home/claude/.ssh";
+        ExecStartPost = "${pkgs.findutils}/bin/find /home/claude/.ssh -type f -exec chmod 600 {} \\;";
+      };
+    };
+  };
+
+  # Disable services that don't work well in WSL
+  services = {
+    # These typically don't work in WSL
+    xserver.enable = false;
+    printing.enable = false;
+    avahi.enable = false;
+  };
+
+  # Boot configuration for WSL
+  boot = {
+    # WSL handles its own kernel
+    isContainer = true;
+  };
+}


### PR DESCRIPTION
- Add virgil host configuration for WSL development environment
- Create modular profile system with base, physical, and WSL profiles
- Introduce mkHost helper function for consistent host definitions
- Extract common configuration to reduce duplication
- Support host types (physical, wsl) and roles (desktop, development)

This refactoring makes it easier to:
- Add new hosts with minimal boilerplate
- Maintain consistency across multiple machines
- Share common settings while preserving host-specific customizations