### PR TITLE
fix(eto): add NetworkManager OpenVPN plugin

### DIFF
--- a/hosts/eto/networking.nix
+++ b/hosts/eto/networking.nix
@@ -1,9 +1,14 @@
+{ pkgs, ... }:
+
 {
   networking = {
     hostName = "eto";
 
     networkmanager = {
       enable = true;
+      plugins = with pkgs; [
+        networkmanager-openvpn
+      ];
       wifi.powersave = false;
       unmanaged = [
         "interface-name:docker0"


### PR DESCRIPTION
## Summary
- add `networkmanager-openvpn` to `networking.networkmanager.plugins` for `eto`
- account for the NixOS 25.11 change where VPN plugins are no longer bundled by default
- restore existing OpenVPN profiles that depend on `org.freedesktop.NetworkManager.openvpn`

## Testing
- built the updated `eto` configuration successfully
- confirmed `networkmanager-openvpn` is explicitly configured via `networking.networkmanager.plugins`
