### PR TITLE
feat: add chetter aws host configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,13 @@
           ];
         };
 
+        # Physical headless machine
+        chetter = mkHost {
+          hostName = "chetter";
+          hostType = "vm";
+          hostRoles = [ "development" ];
+        };
+
         # WSL development environment
         virgil = mkHost {
           hostName = "virgil";

--- a/hosts/chetter/boot.nix
+++ b/hosts/chetter/boot.nix
@@ -1,0 +1,51 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+{
+  boot = {
+    # Match the current AWS instance layout: BIOS boot, GRUB, serial console.
+    growPartition = true;
+    loader = {
+      systemd-boot.enable = lib.mkForce false;
+      grub = {
+        enable = true;
+        device = "/dev/nvme0n1";
+        extraConfig = ''
+          serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+          terminal_output console serial
+          terminal_input console serial
+        '';
+      };
+      timeout = 1;
+    };
+    extraModulePackages = [ config.boot.kernelPackages.ena ];
+    kernelParams = [
+      "panic=1"
+      "boot.panic_on_fail"
+      "vga=0x317"
+      "nomodeset"
+      "console=ttyS0,115200n8"
+      "random.trust_cpu=on"
+    ];
+    blacklistedKernelModules = [
+      "nouveau"
+      "xen_fbfront"
+    ];
+    kernel.sysctl = {
+      "fs.inotify.max_user_instances" = 8192;
+    };
+  };
+
+  systemd = {
+    enableEmergencyMode = false;
+    services = {
+      "serial-getty@ttyS0".enable = true;
+      "serial-getty@hvc0".enable = false;
+      "getty@tty1".enable = false;
+      "autovt@".enable = false;
+    };
+  };
+}

--- a/hosts/chetter/default.nix
+++ b/hosts/chetter/default.nix
@@ -1,0 +1,40 @@
+# chetter - Physical headless machine configuration
+{ pkgs, ... }:
+
+{
+  imports = [
+    ../../modules/profiles/developer.nix
+    ./hardware.nix
+    ./boot.nix
+    ./networking.nix
+    ./virtualisation.nix
+    ./users.nix
+    ./programs.nix
+    ./security.nix
+    ./services.nix
+  ];
+
+  modules = {
+    # CPU-specific optimization
+    system.nix.maxJobs = 28;
+
+    profiles = {
+      developer = {
+        enable = true;
+        languages = [
+          "c"
+          "nix"
+        ];
+        editor = "emacs";
+        enableContainers = false;
+      };
+
+      # Headless hosts do not need a desktop input method daemon.
+      japanese.inputMethod = "none";
+    };
+  };
+
+  environment.systemPackages = with pkgs; [
+    yubico-pam
+  ];
+}

--- a/hosts/chetter/hardware-configuration.nix
+++ b/hosts/chetter/hardware-configuration.nix
@@ -1,0 +1,25 @@
+# Generated from the chetter AWS instance.
+{
+  lib,
+  ...
+}:
+
+{
+  boot = {
+    initrd = {
+      availableKernelModules = [ "nvme" ];
+      kernelModules = [ ];
+    };
+    kernelModules = [ ];
+    extraModulePackages = [ ];
+  };
+
+  fileSystems."/" = {
+    device = "/dev/disk/by-uuid/f222513b-ded1-49fa-b591-20ce86a2fe7f";
+    fsType = "ext4";
+  };
+
+  swapDevices = [ ];
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/hosts/chetter/hardware.nix
+++ b/hosts/chetter/hardware.nix
@@ -1,0 +1,36 @@
+# Hardware configuration wrapper
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  repoHardwareConfig = ./hardware-configuration.nix;
+  systemHardwareConfig = /etc/nixos/hardware-configuration.nix;
+  hasRepoHardwareConfig = builtins.pathExists repoHardwareConfig;
+  hasSystemHardwareConfig = builtins.pathExists systemHardwareConfig;
+in
+{
+  imports =
+    lib.optional hasRepoHardwareConfig repoHardwareConfig
+    ++ lib.optional (!hasRepoHardwareConfig && hasSystemHardwareConfig) systemHardwareConfig;
+
+  assertions = [
+    {
+      assertion = hasRepoHardwareConfig || hasSystemHardwareConfig;
+      message = ''
+        chetter requires a hardware-configuration.nix that defines the root file system.
+        Add hosts/chetter/hardware-configuration.nix to this repository, or ensure
+        /etc/nixos/hardware-configuration.nix exists on the target machine.
+      '';
+    }
+  ];
+
+  hardware = {
+    enableRedistributableFirmware = lib.mkDefault true;
+    cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+    ledger.enable = true;
+  };
+}

--- a/hosts/chetter/networking.nix
+++ b/hosts/chetter/networking.nix
@@ -1,0 +1,27 @@
+{ pkgs, ... }:
+
+{
+  networking = {
+    timeServers = [ "169.254.169.123" ];
+
+    networkmanager = {
+      enable = true;
+      plugins = with pkgs; [
+        networkmanager-openvpn
+      ];
+      wifi.powersave = false;
+      unmanaged = [
+        "interface-name:docker0"
+        "interface-name:br-*"
+        "interface-name:veth*"
+        "interface-name:virbr*"
+      ];
+    };
+
+    firewall = {
+      enable = true;
+      checkReversePath = false;
+      allowPing = true;
+    };
+  };
+}

--- a/hosts/chetter/programs.nix
+++ b/hosts/chetter/programs.nix
@@ -1,0 +1,9 @@
+{
+  programs = {
+    fish.enable = true;
+
+    _1password = {
+      enable = true;
+    };
+  };
+}

--- a/hosts/chetter/security.nix
+++ b/hosts/chetter/security.nix
@@ -1,0 +1,14 @@
+{
+  # chetter is administered via SSH keys on AWS, so wheel users need
+  # passwordless sudo unless a local password is managed separately.
+  security.sudo.wheelNeedsPassword = false;
+
+  security.pam.loginLimits = [
+    {
+      domain = "*";
+      type = "soft";
+      item = "nofile";
+      value = "unlimited";
+    }
+  ];
+}

--- a/hosts/chetter/services.nix
+++ b/hosts/chetter/services.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+
+{
+  services = {
+    keybase.enable = true;
+    pcscd.enable = true;
+
+    udev.packages = [
+      pkgs.amazon-ec2-utils
+      pkgs.yubikey-personalization
+      pkgs.ledger-udev-rules
+    ];
+
+    locate = {
+      enable = true;
+      package = pkgs.plocate;
+    };
+  };
+}

--- a/hosts/chetter/users.nix
+++ b/hosts/chetter/users.nix
@@ -1,0 +1,21 @@
+{
+  users.users.claude = {
+    isNormalUser = true;
+    home = "/home/claude";
+    description = "Takafumi Asano";
+    shell = "/run/current-system/sw/bin/elvish";
+    extraGroups = [
+      "wheel"
+      "networkmanager"
+      "docker"
+      "libvirtd"
+    ];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICHtv7BugMwASTVv4+FZi3HlSke0cCNogLuTQQVm/aWc"
+      # Biometric key for Terminus on the device "zoe"
+      "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA0Izr6fwz7d/QNd3sao8KW7ymotB/HOFkM9V/V44NGxR95tktSX0zlEGM5OSTsLp35qemH6ix5z29RzPowJVsg="
+      # Biometric key for Terminus on the device "russell"
+      "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBj8Q6cfjjNjgL9rlMxNkffiS/YyHjtwulHQR+7/ugJhRRm+5i7hxlEmYVjK74IIPHfo9UrXVOxkmfaKgnIVDDU="
+    ];
+  };
+}

--- a/hosts/chetter/virtualisation.nix
+++ b/hosts/chetter/virtualisation.nix
@@ -1,0 +1,6 @@
+{
+  virtualisation = {
+    docker.enable = true;
+    libvirtd.enable = true;
+  };
+}


### PR DESCRIPTION
## Summary
- add `chetter` to the flake as a new AWS-hosted headless development machine
- add host-specific AWS configuration for BIOS/GRUB boot, serial console, hardware config, and EC2 networking/time defaults
- provision the `claude` user, SSH authorized keys, and passwordless `sudo` for key-based administration

## Validation
- `nix eval --impure --raw .#nixosConfigurations.chetter.config.networking.hostName`
- `nix build --impure --no-link --dry-run .#nixosConfigurations.chetter.config.system.build.toplevel`
- confirmed the instance worked after redeploy on `chetter`
