### PR TITLE
fix: use maintained Docker package

### DIFF
--- a/hosts/chetter/virtualisation.nix
+++ b/hosts/chetter/virtualisation.nix
@@ -1,6 +1,11 @@
+{ pkgs, ... }:
+
 {
   virtualisation = {
-    docker.enable = true;
+    docker = {
+      enable = true;
+      package = pkgs.docker_29;
+    };
     libvirtd.enable = true;
   };
 }

--- a/hosts/eto/virtualisation.nix
+++ b/hosts/eto/virtualisation.nix
@@ -1,6 +1,11 @@
+{ pkgs, ... }:
+
 {
   virtualisation = {
-    docker.enable = true;
+    docker = {
+      enable = true;
+      package = pkgs.docker_29;
+    };
     libvirtd.enable = true;
   };
 }


### PR DESCRIPTION
## Summary
- Pin Docker to pkgs.docker_29 for chetter and eto
- Avoid permitting insecure docker-28.5.2 after nixpkgs marked Docker 28 unmaintained

## Validation
- nix fmt hosts/chetter/virtualisation.nix hosts/eto/virtualisation.nix
- nix eval --impure --raw .#nixosConfigurations.chetter.config.virtualisation.docker.package.version
- nix eval --impure --raw .#nixosConfigurations.eto.config.virtualisation.docker.package.version
- nix build --dry-run --impure --no-link .#nixosConfigurations.chetter.config.system.build.toplevel
- nix build --dry-run --impure --no-link .#nixosConfigurations.eto.config.system.build.toplevel
- nix build --impure --no-link .#checks.x86_64-linux.pre-commit-check