### PR TITLE
feat: update NixOS to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -107,16 +107,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780952837,
-        "narHash": "sha256-Fwd1+spDtQ0hDyBwme6ufG3n4mY0UrjjFdYHv+G/Hds=",
+        "lastModified": 1781808408,
+        "narHash": "sha256-0sOb6OIaD/K1zHxBhpmlKvkADfe0n8+l4Jj2e1Q0r3w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e820eb4a444b46a19b2e03e8dfd2359439ff30fe",
+        "rev": "e8210c649915deed7080033cdbabcc19e40bb899",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A collection of my NixOS configurations for various machines";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixos-wsl.url = "github:nix-community/NixOS-WSL/main";
     pre-commit-hooks = {

--- a/hosts/eto/default.nix
+++ b/hosts/eto/default.nix
@@ -76,10 +76,10 @@
     yubico-pam
 
     # X utilities
-    xorg.xev
-    xorg.xmodmap
-    xorg.xrandr
-    xorg.xmessage
+    xev
+    xmodmap
+    xrandr
+    xmessage
 
     # Desktop utilities
     networkmanagerapplet

--- a/hosts/eto/services.nix
+++ b/hosts/eto/services.nix
@@ -35,7 +35,7 @@
       displayManager.lightdm.extraSeatDefaults = ''
         display-setup-script=${pkgs.writeScript "lightdm-display-setup" ''
           #!${pkgs.bash}/bin/bash
-          ${pkgs.xorg.xrandr}/bin/xrandr --output DP-2 --mode 3840x2160 --rate 60.0 --primary --output DP-4 --mode 3840x2160 --rate 60.0 --left-of DP-2
+          ${pkgs.xrandr}/bin/xrandr --output DP-2 --mode 3840x2160 --rate 60.0 --primary --output DP-4 --mode 3840x2160 --rate 60.0 --left-of DP-2
         ''}
       '';
     };

--- a/modules/profiles/wsl.nix
+++ b/modules/profiles/wsl.nix
@@ -37,9 +37,6 @@
 
   # WSL specific packages
   environment.systemPackages = with pkgs; [
-    # WSL utilities
-    wslu
-
     # Network tools for WSL
     socat
   ];


### PR DESCRIPTION
## Summary
- update the main nixpkgs input from nixos-25.11 to nixos-26.05
- update the nixpkgs lock entry for 26.05
- update eto X utility package references required by 26.05
- remove the discontinued wslu package from the WSL profile; NixOS-WSL still provides wslpath via wsl.extraBin
- keep system.stateVersion at 25.11 for compatibility

## Stacking
- Base PR: #138
- This PR should be merged after #138.

## Validation
- nix eval --impure --raw .#nixosConfigurations.eto.config.system.nixos.release => 26.05
- nix eval --impure --raw .#nixosConfigurations.chetter.config.system.nixos.release => 26.05
- nix eval --impure --raw .#nixosConfigurations.virgil.config.system.nixos.release => 26.05
- nix eval --impure --raw .#nixosConfigurations.eto.config.system.stateVersion => 25.11
- nix eval --impure --raw .#nixosConfigurations.chetter.config.system.stateVersion => 25.11
- nix eval --impure --raw .#nixosConfigurations.virgil.config.system.stateVersion => 25.11
- nix flake check --impure --all-systems --no-build
- nix build --dry-run --impure --no-link .#nixosConfigurations.eto.config.system.build.toplevel
- nix build --dry-run --impure --no-link .#nixosConfigurations.chetter.config.system.build.toplevel
- nix build --dry-run --impure --no-link .#nixosConfigurations.virgil.config.system.build.toplevel
- nix build --impure --no-link .#checks.x86_64-linux.pre-commit-check
- git diff --check

Local validation commands completed without warning diagnostics.
