### PR TITLE
chore: clean up CI and Nix tooling warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@ jobs:
     name: Check flake
     runs-on: ubuntu-latest
     steps:
+      - name: Configure runner defaults
+        run: |
+          git config --global init.defaultBranch main
+          sudo sed -i -E \
+            -e 's/^[#[:space:]]*SYS_UID_MAX[[:space:]]+.*/SYS_UID_MAX 39999/' \
+            -e 's/^[#[:space:]]*SYS_GID_MAX[[:space:]]+.*/SYS_GID_MAX 39999/' \
+            /etc/login.defs
+
       - name: Checkout repository
         # actions/checkout v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -22,15 +30,13 @@ jobs:
           persist-credentials: false
 
       - name: Install Nix
-        # DeterminateSystems/nix-installer-action v22
-        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
+        # cachix/install-nix-action v31.10.6
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
         with:
-          extra-conf: |
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
             experimental-features = nix-command flakes
-
-      - name: Setup Nix cache
-        # DeterminateSystems/magic-nix-cache-action v13
-        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
+            trusted-users = root runner
 
       - name: Check flake
         run: |
@@ -48,12 +54,20 @@ jobs:
           }
           EOF
           fi
-          nix flake check --impure
+          nix flake check --impure --all-systems --no-build
 
   lint-and-format:
     name: Lint and format check
     runs-on: ubuntu-latest
     steps:
+      - name: Configure runner defaults
+        run: |
+          git config --global init.defaultBranch main
+          sudo sed -i -E \
+            -e 's/^[#[:space:]]*SYS_UID_MAX[[:space:]]+.*/SYS_UID_MAX 39999/' \
+            -e 's/^[#[:space:]]*SYS_GID_MAX[[:space:]]+.*/SYS_GID_MAX 39999/' \
+            /etc/login.defs
+
       - name: Checkout repository
         # actions/checkout v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -61,15 +75,13 @@ jobs:
           persist-credentials: false
 
       - name: Install Nix
-        # DeterminateSystems/nix-installer-action v22
-        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
+        # cachix/install-nix-action v31.10.6
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
         with:
-          extra-conf: |
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
             experimental-features = nix-command flakes
-
-      - name: Setup Nix cache
-        # DeterminateSystems/magic-nix-cache-action v13
-        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
+            trusted-users = root runner
 
       - name: Run pre-commit checks
         run: |
@@ -82,6 +94,14 @@ jobs:
       matrix:
         host: [eto, virgil]
     steps:
+      - name: Configure runner defaults
+        run: |
+          git config --global init.defaultBranch main
+          sudo sed -i -E \
+            -e 's/^[#[:space:]]*SYS_UID_MAX[[:space:]]+.*/SYS_UID_MAX 39999/' \
+            -e 's/^[#[:space:]]*SYS_GID_MAX[[:space:]]+.*/SYS_GID_MAX 39999/' \
+            /etc/login.defs
+
       - name: Checkout repository
         # actions/checkout v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -89,15 +109,13 @@ jobs:
           persist-credentials: false
 
       - name: Install Nix
-        # DeterminateSystems/nix-installer-action v22
-        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
+        # cachix/install-nix-action v31.10.6
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
         with:
-          extra-conf: |
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
             experimental-features = nix-command flakes
-
-      - name: Setup Nix cache
-        # DeterminateSystems/magic-nix-cache-action v13
-        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
+            trusted-users = root runner
 
       - name: Create dummy hardware configuration
         run: |

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -14,6 +14,14 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      - name: Configure runner defaults
+        run: |
+          git config --global init.defaultBranch main
+          sudo sed -i -E \
+            -e 's/^[#[:space:]]*SYS_UID_MAX[[:space:]]+.*/SYS_UID_MAX 39999/' \
+            -e 's/^[#[:space:]]*SYS_GID_MAX[[:space:]]+.*/SYS_GID_MAX 39999/' \
+            /etc/login.defs
+
       - name: Checkout repository
         # actions/checkout v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -21,23 +29,31 @@ jobs:
           persist-credentials: false
 
       - name: Install Nix
-        # DeterminateSystems/nix-installer-action v22
-        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
+        # cachix/install-nix-action v31.10.6
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
         with:
-          extra-conf: |
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
             experimental-features = nix-command flakes
+            trusted-users = root runner
 
       - name: Update flake.lock
-        # DeterminateSystems/update-flake-lock v28
-        uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6
+        run: nix flake update
+
+      - name: Create pull request
+        # peter-evans/create-pull-request v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pr-title: "chore: update flake.lock"
-          pr-body: |
+          branch: chore/update-flake-lock
+          delete-branch: true
+          commit-message: "chore: update flake.lock"
+          title: "chore: update flake.lock"
+          body: |
             Automated update of `flake.lock` file.
 
             This PR updates the following inputs to their latest versions.
             Please review the changes and ensure all tests pass before merging.
-          pr-labels: |
+          labels: |
             dependencies
             automated

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This project uses pre-commit hooks to maintain code quality. The following check
 
 **Nix files:**
 
-- nixfmt-rfc-style: Formats code according to RFC-166
+- nixfmt: Formats Nix code
 - deadnix: Detects unused bindings and imports
 - statix: Identifies anti-patterns and suggests improvements
 

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
       };
 
       # Formatter for nix files
-      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt);
 
       checks = forAllSystems (
         system:
@@ -112,6 +112,7 @@
               # Nix
               nixfmt-rfc-style = systemHook // {
                 enable = true;
+                package = nixpkgs.legacyPackages.${system}.nixfmt;
               };
               deadnix = systemHook // {
                 enable = true;

--- a/modules/profiles/developer.nix
+++ b/modules/profiles/developer.nix
@@ -138,7 +138,7 @@ in
       ])
       ++ (optionals (elem "nix" cfg.languages) [
         nil
-        nixfmt-rfc-style
+        nixfmt
         nix-prefetch-scripts
         nix-tree
         nix-diff


### PR DESCRIPTION
## Summary
- switch CI to pinned cachix/install-nix-action and remove magic-nix-cache-action warning noise
- configure ephemeral runner defaults to avoid Git init and Nix builder user warnings
- make flake check validate all systems without building to avoid incompatible-system warnings
- replace the scheduled flake update composite action with nix flake update plus pinned peter-evans/create-pull-request
- use pkgs.nixfmt instead of the deprecated nixfmt-rfc-style package while keeping the hook id for compatibility

## Stacking
- This PR should merge before #137.
- Follow-up PR: #137 updates NixOS to 26.05 on top of this cleanup.

## Validation
- nix flake check --impure --all-systems --no-build
- nix build --impure --no-link .#checks.x86_64-linux.pre-commit-check
- git diff --check

This is intended to land before the NixOS 26.05 update PR so that the version update diff stays focused.
