### PR TITLE
fix: trigger CI for automated flake update PRs

### DIFF
--- a/.github/actions/create-automation-token/action.yml
+++ b/.github/actions/create-automation-token/action.yml
@@ -1,0 +1,96 @@
+name: Create automation token
+description: Create a least-privilege GitHub App installation token for automation PRs.
+
+inputs:
+  app-id:
+    description: GitHub App ID.
+    required: true
+  private-key:
+    description: GitHub App private key in PEM format.
+    required: true
+  installation-id:
+    description: GitHub App installation ID for this account or repository.
+    required: true
+
+outputs:
+  token:
+    description: GitHub App installation token.
+    value: ${{ steps.token.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - id: token
+      shell: bash
+      env:
+        APP_ID: ${{ inputs.app-id }}
+        APP_PRIVATE_KEY: ${{ inputs.private-key }}
+        APP_INSTALLATION_ID: ${{ inputs.installation-id }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$APP_ID" ] || [ -z "$APP_PRIVATE_KEY" ] || [ -z "$APP_INSTALLATION_ID" ]; then
+          echo "GitHub App ID, private key, and installation ID are required." >&2
+          exit 1
+        fi
+
+        tmp_dir="$(mktemp -d)"
+        trap 'rm -rf "$tmp_dir"' EXIT
+
+        key_file="$tmp_dir/app-private-key.pem"
+        printf '%s\n' "$APP_PRIVATE_KEY" > "$key_file"
+        chmod 600 "$key_file"
+
+        b64url() {
+          openssl base64 -A | tr '+/' '-_' | tr -d '='
+        }
+
+        now="$(date +%s)"
+        iat="$((now - 60))"
+        exp="$((now + 540))"
+        header="$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)"
+        payload="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$iat" "$exp" "$APP_ID" | b64url)"
+        signature="$(
+          printf '%s.%s' "$header" "$payload" \
+            | openssl dgst -sha256 -sign "$key_file" -binary \
+            | b64url
+        )"
+        jwt="$header.$payload.$signature"
+
+        repo_name="${GITHUB_REPOSITORY#*/}"
+        request_body="$(
+          REPO_NAME="$repo_name" python3 - <<'PY'
+        import json
+        import os
+
+        print(json.dumps({
+            "repositories": [os.environ["REPO_NAME"]],
+            "permissions": {
+                "contents": "write",
+                "pull_requests": "write",
+            },
+        }))
+        PY
+        )"
+
+        response="$(
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $jwt" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --data "$request_body" \
+            "https://api.github.com/app/installations/${APP_INSTALLATION_ID}/access_tokens"
+        )"
+        token="$(
+          printf '%s' "$response" \
+            | python3 -c 'import json, sys; print(json.load(sys.stdin)["token"])'
+        )"
+
+        if [ -z "$token" ]; then
+          echo "Failed to create GitHub App installation token." >&2
+          exit 1
+        fi
+
+        echo "::add-mask::$token"
+        echo "token=$token" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update:
@@ -40,11 +39,30 @@ jobs:
       - name: Update flake.lock
         run: nix flake update
 
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create automation token
+        id: automation-token
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          installation-id: ${{ secrets.AUTOMATION_APP_INSTALLATION_ID }}
+
       - name: Create pull request
+        if: steps.changes.outputs.has_changes == 'true'
         # peter-evans/create-pull-request v8.1.1
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.automation-token.outputs.token }}
           branch: chore/update-flake-lock
           delete-branch: true
           commit-message: "chore: update flake.lock"


### PR DESCRIPTION
## Summary

- Add a composite action that creates repository-scoped GitHub App installation tokens.
- Use the GitHub App token for automated `flake.lock` pull requests instead of `GITHUB_TOKEN`, so normal CI is triggered for bot updates.
- Skip token creation and PR creation when `nix flake update` produces no changes.

## Verification

- `nix develop --command pre-commit run --files .github/workflows/update-flake.yml .github/actions/create-automation-token/action.yml`

## Required repository secrets

- `AUTOMATION_APP_ID`
- `AUTOMATION_APP_PRIVATE_KEY`
- `AUTOMATION_APP_INSTALLATION_ID`
