### PR TITLE
feat(chetter): add isolated WireGuard access for Even Terminal

### DIFF
--- a/hosts/chetter/EVEN_TERMINAL.md
+++ b/hosts/chetter/EVEN_TERMINAL.md
@@ -1,0 +1,59 @@
+# Even Terminal over WireGuard
+
+`chetter` exposes WireGuard on UDP port 51820. Even Terminal is reachable only from the registered
+iPhone peer at `10.77.0.1:3456`.
+
+The generated iPhone configuration is stored outside Git with mode `0600`:
+
+```text
+~/.config/wireguard/chetter-even-iphone.conf
+```
+
+Import that file into the WireGuard app on the iPhone. It routes only `10.77.0.1/32`; it does not
+route the AWS VPC or general Internet traffic.
+
+## Start Even Terminal
+
+The application token is stored outside Git with mode `0600`:
+
+```text
+~/.config/even-terminal/token
+```
+
+Start Even Terminal interactively as `claude`, selecting the WireGuard interface explicitly:
+
+```bash
+even-terminal \
+  --interface wg0 \
+  --port 3456 \
+  --token "$(<~/.config/even-terminal/token)" \
+  --provider codex \
+  --cwd "$HOME/Codex/github.com/cariandrum22/configuration.nix"
+```
+
+Verify that it listens only on the WireGuard address:
+
+```bash
+ss -ltnp 'sport = :3456'
+```
+
+The expected local address is `10.77.0.1:3456`, not `0.0.0.0:3456` or the EC2 address.
+
+## Validate connectivity
+
+After deploying the NixOS configuration and allowing UDP/51820 in the AWS Security Group:
+
+```bash
+ip address show wg0
+sudo wg show wg0
+```
+
+Connect the Even app to the direct address first:
+
+```text
+http://10.77.0.1:3456
+```
+
+Only after direct-IP validation, create a DNS record such as
+`even.chetter.stultitia.me -> 10.77.0.1` and switch the app to that hostname. TCP/3456 must not be
+added to the EC2 Security Group.

--- a/hosts/chetter/default.nix
+++ b/hosts/chetter/default.nix
@@ -8,6 +8,7 @@
     ./hardware.nix
     ./boot.nix
     ./networking.nix
+    ./even-terminal-wireguard.nix
     ./virtualisation.nix
     ./users.nix
     ./programs.nix

--- a/hosts/chetter/even-terminal-wireguard.nix
+++ b/hosts/chetter/even-terminal-wireguard.nix
@@ -49,6 +49,7 @@ in
             type filter hook input priority -10; policy accept;
 
             iifname "${wireguardInterface}" ip saddr != ${iphoneAddress} counter drop comment "reject spoofed WireGuard source"
+            iifname "${wireguardInterface}" ip daddr != ${wireguardAddress} counter drop comment "restrict WireGuard to its host address"
             iifname "${wireguardInterface}" meta l4proto != tcp counter drop comment "restrict WireGuard to Even Terminal"
             iifname "${wireguardInterface}" tcp dport != ${toString evenTerminalPort} counter drop comment "restrict WireGuard to Even Terminal"
           }

--- a/hosts/chetter/even-terminal-wireguard.nix
+++ b/hosts/chetter/even-terminal-wireguard.nix
@@ -1,0 +1,71 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  externalInterface = "ens5";
+  wireguardInterface = "wg0";
+  wireguardAddress = "10.77.0.1";
+  iphoneAddress = "10.77.0.2";
+  wireguardPort = 51820;
+  evenTerminalPort = 3456;
+  privateKeySecret = "chetter/even-terminal-wireguard/private-key";
+in
+{
+  environment.systemPackages = [ pkgs.wireguard-tools ];
+
+  sops.secrets.${privateKeySecret} = {
+    sopsFile = ./even-terminal-wireguard.secrets.yaml;
+    owner = "root";
+    group = "root";
+    mode = "0400";
+    restartUnits = [ "wireguard-${wireguardInterface}.service" ];
+  };
+
+  networking = {
+    networkmanager.unmanaged = [ "interface-name:${wireguardInterface}" ];
+
+    wireguard.interfaces.${wireguardInterface} = {
+      ips = [ "${wireguardAddress}/24" ];
+      listenPort = wireguardPort;
+      privateKeyFile = config.sops.secrets.${privateKeySecret}.path;
+
+      peers = [
+        {
+          publicKey = "IobwH6TBCi9xR/YjOdcUJ/pq0vHFow7yCTnMXlY0CnM=";
+          allowedIPs = [ "${iphoneAddress}/32" ];
+        }
+      ];
+    };
+
+    nftables = {
+      enable = true;
+      tables."even-terminal-wireguard-isolation" = {
+        family = "inet";
+        content = ''
+          chain input {
+            type filter hook input priority -10; policy accept;
+
+            iifname "${wireguardInterface}" ip saddr != ${iphoneAddress} counter drop comment "reject spoofed WireGuard source"
+            iifname "${wireguardInterface}" meta l4proto != tcp counter drop comment "restrict WireGuard to Even Terminal"
+            iifname "${wireguardInterface}" tcp dport != ${toString evenTerminalPort} counter drop comment "restrict WireGuard to Even Terminal"
+          }
+
+          chain forward {
+            type filter hook forward priority -10; policy accept;
+
+            iifname "${wireguardInterface}" counter drop comment "block WireGuard access to VPC"
+            oifname "${wireguardInterface}" counter drop comment "block routed traffic to WireGuard"
+          }
+        '';
+      };
+    };
+
+    firewall.interfaces = {
+      ${externalInterface}.allowedUDPPorts = [ wireguardPort ];
+      ${wireguardInterface}.allowedTCPPorts = [ evenTerminalPort ];
+    };
+  };
+}

--- a/hosts/chetter/even-terminal-wireguard.secrets.yaml
+++ b/hosts/chetter/even-terminal-wireguard.secrets.yaml
@@ -1,0 +1,18 @@
+chetter:
+    even-terminal-wireguard:
+        private-key: ENC[AES256_GCM,data:V2YHj550A224XBf+JPvxtNJ3WmVpcCZ//sfxRxgv/h3cA8fRSEwxdJe+fhU=,iv:oVisJ2tqhMC2gOW7hSBSj4aGSICeDv3Kef7K+wnFndU=,tag:PtJOxgzkLU1935i/dvw/zw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvUEtGckdDaC83SEtZQUtI
+            UnVzam5hUTU2N215c2ZvSGw0MFNKU0Y5cFFBCndxdzVtWGNRTXlKbmJXUjIrQ3gz
+            Y0pLZ1BpQUJBNjNxcEFYS1IwVkw4eDAKLS0tIE9uOTM1Y2dMdmQvTFc1TklJRnVF
+            QWtSd2EvWmZQMjdaMHVZRElKQUJqZ0EKOf+jmOb4XE0rntX/rf7wbAHzovaItJ+v
+            BMd7v+uLt2k9RCurqgYPBCGEFECkF6BOIdjRiyRMZS5G8ZpCWUYgTw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ax7h2qgh9jj72wyegsz428w2ezay02ll7rcxqvqq32uml0ffxghqanh9v2
+    lastmodified: "2026-08-09T09:58:33Z"
+    mac: ENC[AES256_GCM,data:fHW5gE2R9Ly3YQ4BVP7iQBjpDNKfBtB8g6FWXSjVpNseICu+PvvtoGFPxJikZgRVOPdzTFaxSGb40+5NKBWNzL/mL/rMF/7/WksS9xKemWGoeT1nzB/qmqS7c4tuGHXqwCyF7pMfuLEk677phljoxf6+SXNP5DE7a9sX67B1+/E=,iv:7nUlG3vbVUdpAtNYsrN4FTVlQDdOhjc+YyEiM/Kp9rE=,tag:6vX1pkn2qTwGS/6/skBw/A==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3


### PR DESCRIPTION
## Summary

- configure kernel WireGuard on `wg0` with a single iPhone peer
- store the host private key encrypted with sops-nix
- allow only TCP/3456 from `10.77.0.2` to the tunnel address `10.77.0.1`
- block all forwarding into or out of `wg0`, including access to the AWS VPC
- document interactive startup and direct-IP validation

The Even Terminal package and headless Home Manager integration are provided by cariandrum22/dotfiles#887. Merge and deploy that PR before application-level validation.

## Validation

- `nix build --impure --no-link .#nixosConfigurations.chetter.config.system.build.toplevel`
- `nix flake check --impure --all-systems --no-build`
- pre-commit hooks for all changed files
- decrypted WireGuard private key reproduces the declared host public key

## Deployment requirements

- allow UDP/51820 in the EC2 Security Group
- do not expose TCP/3456 in the EC2 Security Group
- import the locally generated iPhone profile from `~/.config/wireguard/chetter-even-iphone.conf`
- validate `http://10.77.0.1:3456` before adding split DNS

This PR does not change the existing SSH ingress policy. If UDP/51820 must be the only public endpoint, TCP/22 must be removed or source-restricted separately after WireGuard access has been validated to avoid lockout.